### PR TITLE
Fix ECL build: 'strerror' was not declared in scope

### DIFF
--- a/termio/termio.lisp
+++ b/termio/termio.lisp
@@ -69,6 +69,7 @@
 
 ;; Preamble C code needed for ECL's FD-LINE-WIDTH function.
 #+ecl (ffi:clines "
+#include <string.h>
 #include <stdio.h>
 #include <errno.h>
 #include <sys/ioctl.h>")


### PR DESCRIPTION
Context: Ubuntu 20.04, ECL 20.4.24 (latest release) built with CXX support (./configure --with-cxx), using system g++ 9.

Installation fails with:

    ;;; /root/.cache/common-lisp/ecl-20.4.24-6b789092-linux-x64/root/quicklisp/dists/quicklisp/software/clon-1.0b24/termio/termio.cxx:145:10: error: ‘strerror’ was not declared in this scope
    ;;;   145 |    msg = strerror (errno);
    ;;;       |          ^~~~~~~~