### PR TITLE
Adjust .termio.asd to indirectly depend on sb-grovel

### DIFF
--- a/termio/net.didierverna.clon.termio.asd
+++ b/termio/net.didierverna.clon.termio.asd
@@ -50,7 +50,7 @@ Clon, see the net.didierverna.clon system."
 	       :net.didierverna.clon.setup :net.didierverna.clon.core)
   :serial t
   :components (#+sbcl
-	       (sb-grovel:grovel-constants-file "sbcl/constants"
+	       ("sb-grovel:grovel-constants-file" "sbcl/constants"
 		 :package :net.didierverna.clon)
 	       ;; Cf. https://gitlab.common-lisp.net/asdf/asdf/-/issues/63
 	       #+(or allegro clisp lispworks)


### PR DESCRIPTION
- By referencing as a string, asdf will use `uiop:safe-read-from-string` once sb-grovel is available
- As suggested in https://github.com/quicklisp/quicklisp-controller/issues/20

Will eventually fix #9 